### PR TITLE
Add PyTorch config in pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,8 @@ dependencies = [
     "openai>=1.3.8",
     "python-dotenv>=1.1.1",
     "tiktoken>=0.5.0",
+    "torch>=2.7.0",
+    "transformers>=4.40.0",
 ]
 
 [project.scripts]
@@ -24,3 +26,13 @@ pr-review = "prreview:main"
 [build-system]
 requires = ["uv>=0.5.26,<0.6"]
 build-backend = "uv"
+
+[tool.uv.sources]
+torch = [
+    { index = "pytorch-cpu" }
+]
+
+[[tool.uv.index]]
+name = "pytorch-cpu"
+url = "https://download.pytorch.org/whl/cpu"
+explicit = true


### PR DESCRIPTION
## Summary
- add torch and transformers as project dependencies
- configure uv to pull CPU-only PyTorch wheels

## Testing
- `uv pip install torch --index-url https://download.pytorch.org/whl/cpu` *(fails: tunnel error)*
- `uv pip install transformers` *(fails: tunnel error)*
- `uv lock` *(fails: tunnel error)*

------
https://chatgpt.com/codex/tasks/task_e_68707bc135cc8330a0145902fdfa57a9